### PR TITLE
Update lang.php - missing FR translation for 3 options

### DIFF
--- a/lang/fr/lang.php
+++ b/lang/fr/lang.php
@@ -28,3 +28,10 @@ $lang['bt_create_backup'] = 'Créer la sauvegarde';
 $lang['bt_archiving'] = 'Archivage';
 $lang['bt_compressing_archive'] = 'Compression de l\'archive';
 
+$lang['backupnamespace'] = 'Endroit (exemple <code>wiki:backup</code>) où placer les fichiers de sauvegarde.';
+$lang['filterdirs'] = 'Liste des répertoires black-listés, une ligne par répertoire. Ces répertoires ne seront pas 
+inclus dans vos sauvegardes. Si la case-à-cocher suivante est sélectionnée, alors le répertoire de sauvegarde sera
+automatiquement inclu dans la liste.';
+$lang['filterbackups'] = 'Ajouter le répertoire de sauvegarde dans la liste des répertoires ? Il est <em>très
+chaudement</em> recommendé de cocher cette case. Ainsi, les nouvelles sauvegardes n\'incluent pas les anciens
+fichiers de sauvegarde.';


### PR DESCRIPTION
Add 3 translated items which were missing from the EN version ([https://github.com/tatewake/dokuwiki-plugin-backup/blob/master/lang/en/lang.php]).