### PR TITLE
Update date and fix for tatewake/dokuwiki-plugin#22

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -59,15 +59,6 @@ var $backup = '';
 		return 999;
 	}
 	
-	/**
-	 *  return a menu prompt for the admin menu
-	 *  NOT REQUIRED - its better to place $lang['menu'] string in localised string file
-	 *  only use this function when you need to vary the string returned
-	 */
-	function getMenuText()
-	{
-		return 'BackupTool for DokuWiki';
-	}
 
 	/**
 	 * handle user request

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base        backup
 author      Terence J. Grant, Andreas Wagner
 email       tjgrant@tatewake.com, andreas.wagner@em.uni-frankfurt.de
-date        2016-06-28
+date        2016-06-29
 name        BackupTool for DokuWiki
 desc        A tool to backup your data and configuration.
 url         http://www.dokuwiki.org/plugin:backup

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base        backup
 author      Terence J. Grant, Andreas Wagner
 email       tjgrant@tatewake.com, andreas.wagner@em.uni-frankfurt.de
-date        2013-10-09
+date        2016-06-28
 name        BackupTool for DokuWiki
 desc        A tool to backup your data and configuration.
 url         http://www.dokuwiki.org/plugin:backup


### PR DESCRIPTION
This request contains an update for the date of last change of the plugin. Dokuwiki should recognize now that there is an update of the plugin available.

Also, I removed the function getMenuText(), which is not required, if the language files contain the entry $lang['menu']. All language file do so.