### PR TITLE
Skip directory paths when backup

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -317,6 +317,10 @@ class admin_plugin_backup extends DokuWiki_Admin_Plugin
         $rii = new RecursiveIteratorIterator($ri, RecursiveIteratorIterator::SELF_FIRST);
 
         foreach ($rii as $path => $info) {
+            if (is_dir($path)) {
+                continue;
+            }
+
             $file = $this->stripPrefix($path, $dir);
             $file = $as . '/' . $file;
 


### PR DESCRIPTION
Hi @tatewake,

I follow up on the conversation in #43 .

From a logical point of view, i think this patch is appropriate. `RecursiveDirectoryIterator` traverses all paths, including directory path itself, but Tar class support add file only (see [`Tar::addFile`](https://github.com/splitbrain/php-archive/blob/master/src/Tar.php#L249) source code). So check if path is directory is ok.

Patch fix my issue #43 on my Dokuwiki instance, running on hosting with FreeBSD (12.1-STABLE) and PHP 7.4.8 (tested also with PHP 5.6). It is possible that FreeBSD will be the reason, why the function `fread()` return non-empty string for directory path (used [here](https://github.com/splitbrain/php-archive/blob/master/src/Tar.php#L270) in `Tar::addFile`).

It solved the problem for me, maybe it could help someone else.

OS: `FreeBSD 12.1-STABLE`
PHP: `7.4.8`
Dokuwiki: `Release 2020-07-29 "Hogfather"`
Plugin version: `2020-10-21`

Thanks

P.S. It solved the problem for me, it could help someone else ;-)
